### PR TITLE
Create log files in a fixed OS directory instead of the current path

### DIFF
--- a/plex_playlist_creator/logger.py
+++ b/plex_playlist_creator/logger.py
@@ -3,14 +3,20 @@
 import logging
 import os
 import sys
+from pathlib import Path
 
 # Create the logger
 logger = logging.getLogger('plex_playlist_creator')
 
 def configure_logger(log_level='INFO'):
     """Configures the logger with the specified log level."""
-    # Define the log directory path
-    log_dir = os.path.join('logs')
+    # Determine the log directory path based on the OS
+    if os.name == 'nt':  # Windows
+        log_dir = os.path.join(os.getenv('APPDATA'), 'red-plex', 'logs')
+    else:  # Linux/macOS
+        log_dir = os.path.join(Path.home(), '.cache', 'red-plex', 'logs')
+    
+    # Ensure the log directory exists
     os.makedirs(log_dir, exist_ok=True)
 
     # Define the log file path
@@ -39,3 +45,6 @@ def configure_logger(log_level='INFO'):
     # Add handlers to the logger
     logger.addHandler(file_handler)
     logger.addHandler(stream_handler)
+
+    # Log where the logs are being saved for transparency
+    logger.info(f"Logs are being saved to: {log_file_path}")

--- a/plex_playlist_creator/logger.py
+++ b/plex_playlist_creator/logger.py
@@ -15,7 +15,7 @@ def configure_logger(log_level='INFO'):
         log_dir = os.path.join(os.getenv('APPDATA'), 'red-plex', 'logs')
     else:  # Linux/macOS
         log_dir = os.path.join(Path.home(), '.cache', 'red-plex', 'logs')
-    
+
     # Ensure the log directory exists
     os.makedirs(log_dir, exist_ok=True)
 
@@ -47,4 +47,4 @@ def configure_logger(log_level='INFO'):
     logger.addHandler(stream_handler)
 
     # Log where the logs are being saved for transparency
-    logger.info(f"Logs are being saved to: {log_file_path}")
+    logger.info("Logs are being saved to: [%s]", log_file_path)


### PR DESCRIPTION
This pull request includes significant updates to the `plex_playlist_creator/logger.py` file to improve logging configuration and transparency. The changes ensure compatibility with different operating systems and provide better insight into where log files are stored.

Improvements to logging configuration:

* Added import for `Path` from `pathlib` to handle file paths in a more platform-independent manner.
* Updated the log directory path determination to handle differences between Windows and Linux/macOS environments.
* Ensured the log directory exists by using `os.makedirs` with `exist_ok=True`.

Enhancements for transparency:

* Added a log entry to inform where the log files are being saved, improving transparency for users.